### PR TITLE
Fix indexing bug

### DIFF
--- a/backend/game_state.py
+++ b/backend/game_state.py
@@ -122,7 +122,9 @@ class Card:
 
     @classmethod
     def parse_rank(self, index: int) -> int:
-        return index % 13
+        if index < 52:
+            return index % 13 + 1
+        return 0
 
     def __str__(self) -> str:
         if self.__suit == Suit.SMALL_JOKER:


### PR DESCRIPTION
Woops, I forget that the backend assumes a deck is consisted of cards 0-53 instead of specifying individual cards specifically like is done in card.js. I'll merge right away since this breaks backend logic pretty badly.