### PR TITLE
Fix a bug where if a player has one particular card, server allows it to

### DIFF
--- a/backend/ai.py
+++ b/backend/ai.py
@@ -3,16 +3,12 @@ import time
 from game_state import (
     Player,
     Game,
-    TrumpType)
+    TrumpType,
+    getCardNum,
+    toCardProto)
 from shengji_pb2 import (
     Card as CardProto,
     Game as GameProto)
-
-def getCardNum(card: CardProto) -> int:
-    return card.suit * 100 + card.rank
-
-def toCardProto(cardNum: int) -> CardProto:
-    return CardProto(suit = cardNum // 100, rank = cardNum % 100)
 
 class AIBase():
     def __init__(self, game: Game, player: Player) -> None:


### PR DESCRIPTION
play a pair of that card.

Also change cards_on_hand from a list to a dictionary so that add
/ remove / compare can be made a lot faster. It breaks an invariant that
the cards are sorted in the order of they are coming, but I think it
should be okay as we are doing delta update in most cases, and for cases
where delta update fails, we probably do not have time to show
card-by-card dealing animation and prefer to render all cards in hand
instead.

Fixes https://github.com/EccentricTrumpet/SmoothJazz/issues/102