### PR TITLE
Allow players to join by copying match url

### DIFF
--- a/server/servers/http.py
+++ b/server/servers/http.py
@@ -26,7 +26,16 @@ class MatchGet(MethodView):
         if response is None:
             abort(404)
         else:
-            return response.json()
+            return (
+                response.json(),
+                200,
+                {
+                    "Cache-Control": "no-cache, no-store, must-revalidate",
+                    "Pragma": "no-cache",
+                    "Expires": "0",
+                    "Cache-Control": "public, max-age=0",
+                },
+            )
 
 
 def init_http(service: MatchService, static_path: str) -> Flask:

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -12,8 +12,8 @@ function App() {
         <Route path="/">
           <Route index element={<HomePage />} />
           <Route path="/:id" element={<MatchPage />} />
-          <Route path="newMatch" element={<NewMatchPage />} />
-          <Route path="joinMatch" element={<JoinMatchPage />} />
+          <Route path="/newMatch" element={<NewMatchPage />} />
+          <Route path="/joinMatch" element={<JoinMatchPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/webapp/src/pages/JoinMatchPage.tsx
+++ b/webapp/src/pages/JoinMatchPage.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useState } from 'react';
 import { CookiesProvider, useCookies } from 'react-cookie'
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { CookieState } from '../abstractions/states';
 import { MatchResponse } from '../abstractions/messages';
 
 export default function JoinMatchPage() {
+  const [searchParams] = useSearchParams()
   const [cookie, setCookie] = useCookies(['shengji'])
   const [cookieState, setCookieState] = useState(new CookieState());
-  const [match, setMatch] = useState(-1);
+  const [match, setMatch] = useState(parseInt(searchParams.get("match_id") ?? "-1"));
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -58,6 +59,7 @@ export default function JoinMatchPage() {
             type="number"
             name="match"
             placeholder="Match"
+            value={match >= 0 ? match : undefined}
             onChange={handleMatchChange}
             required
           />

--- a/webapp/src/pages/MatchPage.tsx
+++ b/webapp/src/pages/MatchPage.tsx
@@ -1,6 +1,6 @@
 import { motion, AnimatePresence } from "framer-motion";
 import { useEffect, useState } from "react";
-import { useLocation, useParams } from "react-router-dom";
+import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
 import { Manager, Socket } from "socket.io-client";
 import { debounce } from "lodash";
 import { Card, ControllerInterface } from "../abstractions";
@@ -38,11 +38,20 @@ export default function MatchPage() {
   // React states
   const { id } = useParams();
   const { state } = useLocation();
-  const options = new OptionsState("red.png");
+  const navigate = useNavigate();
   const matchId = Number(id);
-  const { name, matchResponse }: {name: string, matchResponse: MatchResponse} = state;
+  const [name] = useState<string>(state?.name);
+  const [matchResponse] = useState<MatchResponse>(state?.matchResponse);
+
+  // Redirect to join match if missing required match data
+  useEffect(() => {
+    if (!state || !name || !matchResponse) {
+      navigate(`/joinMatch?match_id=${matchId}`);
+    }
+  }, [name, matchResponse, navigate, matchId, state]);
 
   // UI states
+  const options = new OptionsState("red.png");
   const [zone, setZone] = useState(new Zone(
     new Position(0, 0),
     new Size(window.innerWidth, window.innerHeight)
@@ -61,7 +70,7 @@ export default function MatchPage() {
   const [gameState, setGameState] = useState(new GameState());
   const [boardState, setBoardState] = useState(new BoardState());
   const [trumpState, setTrumpState] = useState(new TrumpState(0, 0));
-  const [players, setPlayers] = useState(matchResponse.players);
+  const [players, setPlayers] = useState(matchResponse?.players);
   const [socket, setSocket] = useState<Socket>();
 
   // Establish window size


### PR DESCRIPTION
Closes #147 

The match page checks whether the required info including player name and match response exist on the state. If it doesn't, it redirects to the join match page with a specific match id so the player can choose a name and make the request to join the match.